### PR TITLE
feat: add PocketBase cron job management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,41 @@ The server provides the following tools, organized by category:
         }
         ```
 
+### Cron Job Management
+
+> **Note:** The Cron Jobs API requires admin authentication and may not be available in all PocketBase instances or configurations. These tools interact with the PocketBase Cron Jobs API.
+
+-   **list_cron_jobs**: Returns list with all registered app level cron jobs.
+    -   *Input Schema*:
+        ```json
+        {
+          "type": "object",
+          "properties": {
+            "fields": {
+              "type": "string",
+              "description": "Comma separated string of the fields to return in the JSON response (by default returns all fields). Ex.:?fields=*,expand.relField.name"
+            }
+          }
+        }
+        ```
+
+-   **run_cron_job**: Triggers a single cron job by its id.
+    -   *Input Schema*:
+        ```json
+        {
+          "type": "object",
+          "properties": {
+            "jobId": {
+              "type": "string",
+              "description": "The identifier of the cron job to run."
+            }
+          },
+          "required": [
+            "jobId"
+          ]
+        }
+        ```
+
 ### Migration Management
 
 -   **set_migrations_directory**: Set the directory where migration files will be created and read from.
@@ -593,7 +628,9 @@ To use this server with Cline, you need to add it to your MCP settings file (`cl
             "get_collection_schema",
             "list_logs",
             "get_log",
-            "get_logs_stats"
+            "get_logs_stats",
+            "list_cron_jobs",
+            "run_cron_job"
           ] // Suggested auto-approve settings
         }
 

--- a/src/tools/cron-tools.ts
+++ b/src/tools/cron-tools.ts
@@ -1,0 +1,90 @@
+import PocketBase from 'pocketbase';
+
+import {
+    ToolResult, ToolInfo,
+    ListCronJobsArgs, RunCronJobArgs
+} from '../types/index.js'
+import { invalidParamsError } from '../server/error-handler.js';
+
+
+//Define tool information for registration
+const cronToolInfo: ToolInfo[] = [
+    {
+        name: 'list_cron_jobs',
+        description: 'Returns list with all registered app level cron jobs.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                fields: { type: 'string', description: 'Comma separated string of the fields to return in the JSON response (by default returns all fields). Ex.:?fields=*,expand.relField.name' }
+            }
+        }
+    },
+    {
+        name: 'run_cron_job',
+        description: 'Triggers a single cron job by its id.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                jobId: { type: 'string', description: 'The identifier of the cron job to run.' }
+            },
+            required: ['jobId']
+        }
+    }
+];
+
+export function listCronTools(): ToolInfo[] {
+    return cronToolInfo;
+}
+
+// Handle calls for cron-related tools
+export async function handleCronToolCall(name: string, args: any, pb: PocketBase): Promise<ToolResult> {
+    switch (name) {
+        case 'list_cron_jobs':
+            return listCronJobs(args as ListCronJobsArgs, pb);
+        case 'run_cron_job':
+            return runCronJob(args as RunCronJobArgs, pb);
+        default:
+            // This case should ideally not be reached due to routing in index.ts
+            throw new Error(`Unknown cron tool: ${name}`);
+
+    }
+}
+
+// --- Individual Tool Implementations ---
+
+async function listCronJobs(args: ListCronJobsArgs, pb: PocketBase): Promise<ToolResult> {
+    const { fields } = args;
+
+    try {
+        const result = await pb.crons.getFullList({
+            fields
+        });
+
+        return {
+            content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+
+        };
+    } catch (error) {
+        // If there's an error, return a more descriptive error
+        if (error instanceof Error) {
+            return {
+                content: [{ type: 'text', text: `Error fetching cron list: ${error.message}` }],
+                isError: true
+            };
+        }
+        throw error;
+    }
+}
+
+async function runCronJob(args: RunCronJobArgs, pb: PocketBase): Promise<ToolResult> {
+    if (!args.jobId) {
+        throw invalidParamsError("Missing required argument: jobId");
+    }
+    
+    // Make the API request to get a single log
+    const result = await pb.crons.run(args.jobId)
+    
+    return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,7 @@ import { listCollectionTools, handleCollectionToolCall } from './collection-tool
 import { listFileTools, handleFileToolCall } from './file-tools.js';
 import { listMigrationTools, handleMigrationToolCall } from './migration-tools.js'; // Uncommented
 import { listLogTools, handleLogToolCall } from './log-tools.js'; // Import log tools
+import { listCronTools, handleCronToolCall } from './cron-tools.js'; // Import cron tools
 
 // Combine all tool definitions
 export function registerTools(): { tools: ToolInfo[] } { // Use ToolInfo[]
@@ -18,6 +19,7 @@ export function registerTools(): { tools: ToolInfo[] } { // Use ToolInfo[]
         ...listFileTools(),
         ...listMigrationTools(), // Uncommented
         ...listLogTools(), // Add log tools
+        ...listCronTools(), // Add cron tools
     ];
     return { tools };
 }
@@ -50,6 +52,8 @@ export async function handleToolCall(params: CallToolRequest['params'], pb: Pock
         return handleMigrationToolCall(name, toolArgs, pb);
     } else if (name === 'list_logs' || name === 'get_log' || name === 'get_logs_stats') {
         return handleLogToolCall(name, toolArgs, pb);
+    } else if (name === 'list_cron_jobs' || name === 'run_cron_job') {
+        return handleCronToolCall(name, toolArgs, pb);
     } else {
         throw methodNotFoundError(name);
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,7 +13,10 @@ export type {
   // Log API types
   ListLogsArgs,
   GetLogArgs,
-  GetLogsStatsArgs
+  GetLogsStatsArgs,
+  // Cron API types
+  ListCronJobsArgs,
+  RunCronJobArgs
 } from './tool-types.js';
 export * from './pocketbase-types.js'; // Keep wildcard export for potentially generated types
 export * from './migration-types.js'; // Keep wildcard export for now

--- a/src/types/tool-types.ts
+++ b/src/types/tool-types.ts
@@ -89,3 +89,14 @@ export interface GetLogsStatsArgs {
 }
 
 // Add types for new migration tools later
+
+
+// Cron API types
+export interface ListCronJobsArgs {
+  fields?: string;
+}
+
+export interface RunCronJobArgs {
+  jobId: string;
+}
+


### PR DESCRIPTION
# PocketBase MCP: Add Cron Job Management Tools

## Overview

This PR adds support for PocketBase's cron job management capabilities to the PocketBase MCP server. Users can now list all registered app-level cron jobs and trigger specific cron jobs programmatically through the MCP interface.

## Features Added

* **`list_cron_jobs`**: Returns a list of all registered app-level cron jobs
    * Optional `fields` parameter to specify which fields to return
* **`run_cron_job`**: Triggers a single cron job by its ID
    * Requires a `jobId` parameter

## Implementation Details

* Added new tool type definitions in `src/types/tool-types.ts`
* Created cron job tool implementations in `src/tools/cron-tools.ts`
* Registered the new tools in `src/tools/index.ts`
* Exported the necessary types in `src/types/index.ts`
* Added the new tools to the `autoApprove` list in MCP settings

## Testing

Both tools have been thoroughly tested:

* **`list_cron_jobs`**:
    * Successfully returns a list of all registered cron jobs
    * Properly handles the optional `fields` parameter
    * Returns empty objects when non-existent fields are requested
* **`run_cron_job`**:
    * Successfully triggers cron jobs
    * Returns `true` when a job is successfully triggered
    * Returns appropriate error messages for non-existent jobs
    * Properly validates required parameters

## Documentation

* Added a new "**Cron Job Management**" section to the `README.md`
* Included detailed descriptions and input schemas for both tools
* Updated the suggested `autoApprove` settings in the installation instructions

## Breaking Changes

None. This PR only adds new functionality without modifying existing behavior.

## Future Considerations

* Add support for creating and managing custom cron jobs
* Implement a way to monitor cron job execution history
* Add ability to schedule one-time jobs

This release enhances the PocketBase MCP server's capabilities by providing access to PocketBase's cron job system, allowing for better automation and scheduled task management.